### PR TITLE
(サーバーサイド)商品出品機能実装

### DIFF
--- a/app/assets/javascripts/product_new.js
+++ b/app/assets/javascripts/product_new.js
@@ -1,0 +1,172 @@
+document.addEventListener("turbolinks:load", function() {
+  // ドロップリストの選択肢をjsonデータからhtmlにする関数
+  var firstSelecthtml = `<option value="---">---</option>`;
+  function foamHtml(search_result) {
+    var html = `<option value="${search_result.id}">${
+      search_result.name
+    }</option>`;
+    return html;
+  }
+  // 初期設定：後から出てくるドロップダウンリストをdisplay：noneで隠す
+  $(".root-of-delivery_method-for-css").css("display", "none");
+  $(".product__detail__form_box__size").css("display", "none");
+  $(".child_id")
+    .parent()
+    .css("display", "none");
+  $(".grandchild_id")
+    .parent()
+    .css("display", "none");
+  $(".product__detail__form_box__brand").css("display", "none");
+  // 親カテゴリーが入力されたとき子カテゴリーを生成
+  $(".parent_id").change(function() {
+    var parent_id = $(".parent_id").val();
+    $(".grandchild_id")
+      .parent()
+      .css("display", "none");
+    $(".product__detail__form_box__size").css("display", "none");
+    if (parent_id === "---") {
+      $(".child_id")
+        .parent()
+        .css("display", "none");
+    } else {
+      $.ajax({
+        type: "GET",
+        url: "/products/search_category",
+        data: { parent_id: parent_id },
+        dataType: "json"
+      }).done(function(child_ids) {
+        $(".child_id").empty();
+        $(".child_id")
+          .parent()
+          // display:noneの解除
+          .css("display", "");
+        $(".child_id").append(firstSelecthtml);
+        child_ids.forEach(function(child) {
+          var html = foamHtml(child);
+          $(".child_id").append(html);
+        });
+      });
+    }
+  });
+  // 子カテゴリーが入力されたとき孫カテゴリーを生成
+  $(".child_id").change(function() {
+    $(".product__detail__form_box__size").css("display", "none");
+    var parent_id = $(".child_id").val();
+    if (parent_id === "---") {
+      $(".grandchild_id")
+        .parent()
+        .css("display", "none");
+      $(".product__detail__form_box__size").css("display", "none");
+    } else {
+      $.ajax({
+        type: "GET",
+        url: "/products/search_category",
+        data: { parent_id: parent_id },
+        dataType: "json"
+      }).done(function(child_ids) {
+        $(".grandchild_id").empty();
+        $(".grandchild_id").append(firstSelecthtml);
+        $(".grandchild_id")
+          .parent()
+          .css("display", "");
+        if (child_ids.length == 1) {
+          $(".grandchild").empty();
+          $(".grandchild_id")
+            .parent()
+            .css("display", "none");
+        }
+        child_ids.forEach(function(child) {
+          var html = foamHtml(child);
+          $(".grandchild_id").append(html);
+        });
+      });
+    }
+  });
+
+  // 孫カテゴリーが入力されたときサイズカテゴリーを生成
+  $(".grandchild_id").change(function() {
+    var parent_id = $(".grandchild_id").val();
+    if (parent_id === "---") {
+      $(".size_id").empty();
+      $(".size_id").append(firstSelecthtml);
+    } else {
+      $.ajax({
+        type: "GET",
+        url: "/products/search_category",
+        data: { parent_id: parent_id },
+        dataType: "json"
+      }).done(function(size_ids) {
+        $(".size_id").empty();
+        $(".size_id").append(firstSelecthtml);
+        $(".product__detail__form_box__size").css("display", "");
+        $(".product__detail__form_box__brand").css("display", "");
+        // size_idsが１の時はサイズがない時なので場合分け
+        if (size_ids.length == 1) {
+          $(".size_id").empty();
+          $(".product__detail__form_box__size").css("display", "none");
+        }
+        size_ids.forEach(function(size) {
+          var html = foamHtml(size);
+          $(".size_id").append(html);
+        });
+      });
+    }
+  });
+
+  // 配送料の支払い元が確定した時点で配送方法のドロップダウンリストを生成。
+  $("#product_shipping_fee_payer").change(function() {
+    var fee_payer = $("#product_shipping_fee_payer").val();
+    $("#product_delivery_method").empty();
+    $("#product_delivery_method").append(firstSelecthtml);
+    if (fee_payer == "---") {
+      $(".root-of-delivery_method-for-css").attr(
+        "style",
+        "display: none !important;"
+      );
+    } else if (fee_payer == "送料込み（出品者負担）") {
+      $(".root-of-delivery_method-for-css").css("display", "");
+      $("#product_delivery_method").append(
+        ' <option value="未定">未定</option>\
+      <option value="らくらくメルカリ便">らくらくメルカリ便</option>\
+      <option value="ゆうメール">ゆうメール</option>\
+      <option value="レターパック">レターパック</option>\
+      <option value="普通郵便(定形、定形外)">普通郵便(定形、定形外)</option>\
+      <option value="クロネコヤマト">クロネコヤマト</option>\
+      <option value="ゆうパック">ゆうパック</option>\
+      <option value="クリックポスト">クリックポスト</option>\
+      <option value="ゆうパケット">ゆうパケット</option>'
+      );
+    } else if (fee_payer == "着払い（購入者負担）") {
+      $(".root-of-delivery_method-for-css").css("display", "");
+      $("#product_delivery_method").append(
+        ' <option value="未定">未定</option>\
+      <option value="クロネコヤマト">クロネコヤマト</option>\
+      <option value="ゆうパック">ゆうパック</option>\
+      <option value="ゆうメール">ゆうメール</option>\
+      <option value="ゆうパック">ゆうパック</option>'
+      );
+    }
+  });
+
+  // 購入金額から手数料を計算する関数
+  $(".sell-price__text_area_2").on("keyup", function() {
+    var input = $(".sell-price__text_area_2").val();
+    var fee = parseInt(input / 10);
+    if (isNaN(fee) == false && input >= 300 && input <= 9999999) {
+      $(".mercari-share").val(fee);
+      $(".seller-share").val(input - fee);
+    } else {
+      $(".mercari-share").val("-");
+      $(".seller-share").val("-");
+    }
+  });
+});
+
+$(function() {
+  $("#product_brand_id").autocomplete({
+    autoFocus: true,
+    source: "/products/auto_complete.json",
+    minLength: 1,
+    delay: 0
+  });
+});

--- a/app/assets/stylesheets/partials/_categories.scss
+++ b/app/assets/stylesheets/partials/_categories.scss
@@ -1,0 +1,107 @@
+.category {
+  margin: 0 40px 0 40px;
+
+  &__content-btn-category {
+    margin: 30px 140px;
+    height: 270px;
+
+    &__heading {
+      margin: 3px;
+
+      h1 {
+        font: {
+          size: 1.4rem;
+          weight: bold;
+        }
+      }
+    }
+
+    &__btns {
+      .btn-category {
+        color: $black;
+        letter-spacing: 1px;
+        background-color: $white;
+        padding: 10px 40px;
+        margin: 6px 3px 6px;
+        display: inline-block;
+        border-radius: 3px;
+        box-shadow: 0.9px 0.9px 3px $border_gray;
+      }
+
+      .btn-category:hover {
+        background: $red;
+        color: $white;
+        box-shadow: 0.9px 0.9px 2px $border_gray;
+      }
+    }
+  }
+
+  &__content-category-wrapper {
+    padding: 30px 140px;
+
+    &__heading {
+      height: 45px;
+      background-color: $red;
+      border-radius: 3px 3px 0 0;
+
+      h1 {
+        color: $white;
+        line-height: 45px;
+        padding-left: 30px;
+
+        font: {
+          size: 1.4rem;
+          weight: bold;
+        }
+      }
+    }
+
+    &__box {
+      min-height: 500px;
+      background-color: $white;
+      border-radius: 3px;
+      padding: 25px 30px 30px 30px;
+
+      .product-category {
+        color: $light_blue;
+        font-size: 1rem;
+      }
+
+      .product-category:hover {
+        color: $light_blue;
+        opacity: 0.7;
+        font-size: 1rem;
+        text-decoration: underline
+      }
+
+      &__all {
+        margin: 15px;
+      }
+
+      &__product {
+        padding: 10px;
+        margin-bottom: 50px;
+        min-height: 200px;
+
+        p {
+          color: $black;
+
+          font: {
+            size: 0.9rem;
+            weight: bold;
+          }
+        }
+      }
+
+      &__categories {
+        margin: 5px;
+
+        &__name {
+          float: left;
+          width: 50%;
+          margin: 5px 0 5px 0;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,7 +21,7 @@ class ProductsController < ApplicationController
       new_image_params[:images].each do |image|
         @product.product_images.create(image_url: image, product_id: @product.id)
       end
-      Deal.create(seller_id: current_user.id ,product_id: @product.id, status_id:1)
+      Deal.create(seller_id: current_user.id ,product_id: @product.id, position_id:1)
 
       flash[:notice] = '出品が完了しました'
       redirect_to root_path

--- a/app/views/products/search_category.json.jbuilder
+++ b/app/views/products/search_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children do |child|
+  json.id child.id
+  json.name child.name
+end


### PR DESCRIPTION
# WHAT
商品出品機能の実装
商品出品画面のブランド名フォームのオートコンプリート、表示が変わるドロップダウンリストの実装
出品した情報をテーブルに保存
商品画像の保存から完了まで
topページの一覧画面に表示されるまで
＊マスターへマージ後に削除機能や編集・更新機能に着手予定です。
# WHY
商品出品ができるようにするため
# Image
[![Image from Gyazo](https://i.gyazo.com/8af758c27da04108d698f09434fc12a7.gif)](https://gyazo.com/8af758c27da04108d698f09434fc12a7)
#
[![Image from Gyazo](https://i.gyazo.com/13bda5ac2695d5d6147a9486384db909.gif)](https://gyazo.com/13bda5ac2695d5d6147a9486384db909)