### PR TITLE
ユーザープロフィールのニックネームを表示

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -7,6 +7,7 @@ class UserProfilesController < ApplicationController
   end
 
   def edit
+    @user = User.find(current_user.id)
   end
 
   def update

--- a/app/views/user_profiles/edit.html.haml
+++ b/app/views/user_profiles/edit.html.haml
@@ -5,13 +5,14 @@
       .user_mypage__container__edit__title
         %h2 プロフィール
       .user_mypage__container__edit__editform
-      = form_for(@user, url: user_user_profiles_path) do |f|
+      = form_for(@user, url: user_user_profile_path) do |f|
         .user_mypage__container__edit__editform__name
           %figure
-            = image_tag "ねこ2.jpeg", width: "60", height: "60"
+            = image_tag "ねこ２.jpeg", width: "60", height: "60"
           %input{type: "text", name: "nickname",value: "#{@user.nickname}",class: "user_mypage__container__edit__editform__name__inputbox"}
         .user_mypage__container__edit__editform__content
           %textarea{name: "profile_comment"}
-          %button{type: "submit", class: "user_mypage__container__edit__editform__content__submit redbtn"} 変更する
-          -# = link_to user_user_profiles_paths(@user.nickname)
+          %button{type: "submit", class: "user_mypage__container__edit__editform__content__submit redbtn", method: :patch} 変更する
+
+    -# サイドメニュー部分テンプレート
     =render partial: "users/user_side_menu"

--- a/app/views/user_profiles/edit.html.haml
+++ b/app/views/user_profiles/edit.html.haml
@@ -5,13 +5,13 @@
       .user_mypage__container__edit__title
         %h2 プロフィール
       .user_mypage__container__edit__editform
-        -# = form_for(@user) do |f|
+      = form_for(@user, url: user_user_profiles_path) do |f|
         .user_mypage__container__edit__editform__name
           %figure
             = image_tag "ねこ2.jpeg", width: "60", height: "60"
-          %input{type: "text", name: "nickname", class: "user_mypage__container__edit__editform__name__inputbox"}
+          %input{type: "text", name: "nickname",value: "#{@user.nickname}",class: "user_mypage__container__edit__editform__name__inputbox"}
         .user_mypage__container__edit__editform__content
           %textarea{name: "profile_comment"}
           %button{type: "submit", class: "user_mypage__container__edit__editform__content__submit redbtn"} 変更する
-
+          -# = link_to user_user_profiles_paths(@user.nickname)
     =render partial: "users/user_side_menu"


### PR DESCRIPTION
# WHAT
ユーザーのプロフィール編集ページに、カレントユーザーのニックネームを表示させるようにした

# WHY
実装において便利な機能なため

[![Image from Gyazo](https://i.gyazo.com/088676e7aa531eba667a4b11ee10ddfb.png)](https://gyazo.com/088676e7aa531eba667a4b11ee10ddfb)